### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@
 pip install squarecloud-api
 ````
 
-If you intend to use this SDK for command-line interface (CLI) operations, consider
-installing it with pipx:
-````shell
-pipx install squarecloud-api
-````
-
 ## Getting api key
 
 to get your api key/token just go to the [Square Cloud] website and


### PR DESCRIPTION
Removed SDK CLI citation, because the CLI module was removed in this commit: https://github.com/squarecloudofc/sdk-api-py/commit/aca9472f54a1cebf0794bec50e92c38eef761548